### PR TITLE
method for android 7up & down, timestamps, handling screenrecord process

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # gnome-android-tool
-Gnome shell extension for adb tools 
+Gnome shell extension for adb tools
 
 - Take screenshot
 - Record screen
@@ -10,9 +10,9 @@ Gnome shell extension for adb tools
 
 # Installation
 ## Install from extensions website
-- Install extension from https://extensions.gnome.org/extension/1232/android-tool/ 
-  (Waiting for extenaion to be reviewed and approved)
-  
+- Install extension from https://extensions.gnome.org/extension/1232/android-tool/
+  (Waiting for extenaion to be reviewed and approved)
+
 ## Install from Git
 - Create folder `android-tool@naman14.github.com` in `~/.local/share/gnome-shell/extensions`
 - Clone this repository and copy the contents to the above created folder
@@ -20,4 +20,17 @@ Gnome shell extension for adb tools
 
 - Make sure adb is added in path and bash is available
 
+## Changes
+- Android 7.x - native screencap
+- Android <7 - old trimming method with sed (optional alternative perl method)
+- changed timestamp to show also seconds
+- screenrecord is now killed more securelly and before copying file to computer there's a little timeout (`sleep 1`) so the kill process can end safely
+
+## Todo
+- Better support for screen capturing - the kill screenrecord process is a bit buggy and makes videos corrupted
+```
+$ ffmpeg -i
+screenrecord-2017-06-06-15:22:39.mp4: Protocol not found
+Did you mean file:screenrecord-2017-06-06-15:22:39.mp4?
+```
 

--- a/adbhelper.js
+++ b/adbhelper.js
@@ -1,88 +1,133 @@
-
 const GLib = imports.gi.GLib;
 
 function findDevices() {
-  let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb devices -l | awk 'NR>1 {print $1}'"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb devices -l | awk 'NR>1 {print $1}'"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 
-  if(!isEmpty(error.toString())) {
-      return {error: error.toString()};
-  }
+    if (!isEmpty(error.toString())) {
+        return { error: error.toString() };
+    }
 
-  if(!isEmpty(out.toString()))  {
+    if (!isEmpty(out.toString())) {
 
-   let devices = [];
+        let devices = [];
 
-   let array = out.toString().split('\n');
+        let array = out.toString().split('\n');
 
-   for(var i = 0;i < array.length; i++) {
+        for (var i = 0; i < array.length; i++) {
 
-      let deviceId = array[i];
+            let deviceId = array[i];
 
-      if(!isEmpty(deviceId)) {
+            if (!isEmpty(deviceId)) {
 
-         devices.push(getDeviceDetail(deviceId));
-     }
- }
- return {
-  devices : devices
-}
+                devices.push(getDeviceDetail(deviceId));
+            }
+        }
+        return {
+            devices: devices
+        }
 
-} else {
-   return {error: "No devices found"}
-}
-
-
+    } else {
+        return { error: "No devices found" }
+    }
 }
 
 function getDeviceDetail(deviceId) {
-  let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId +" shell getprop ro.product.model"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " shell getprop ro.product.model"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 
-  let device;
+    let device;
 
-  if(!isEmpty(error.toString())) {
-      return;
-  }
+    if (!isEmpty(error.toString())) {
+        return;
+    }
 
-  if(!isEmpty(out.toString()))  {
-   device = {deviceId: deviceId, name : out.toString()}
-   return device;
+    if (!isEmpty(out.toString())) {
+        device = { deviceId: deviceId, name: out.toString() }
+        return device;
+    }
 }
+
+/**
+ * Get Android version
+ */
+function getAndroidVersion(deviceId) {
+    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " shell getprop ro.build.version.release"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+
+    let version;
+
+    if (!isEmpty(error.toString())) {
+        return;
+    }
+
+    if (!isEmpty(out.toString())) {
+        version = { version: out.toString() }
+        return version;
+    }
+}
+
+/**
+ * Get screenrecord process pid
+ */
+function getScreenrecordPid(deviceId) {
+    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " shell ps | grep screenrecord | awk '{print $2}'"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let pid;
+
+    if (!isEmpty(error.toString())) {
+        return;
+    }
+
+    if (!isEmpty(out.toString())) {
+        pid = { pid: out.toString() }
+        return pid;
+    }
 }
 
 //start adb daemon on init
 function startDaemon() {
     GLib.spawn_async(null, ["bash", "-c", "adb devices"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
-
 }
 
 function takeScreenshot(deviceId) {
-
     //current time
-    let time = '$(date +%Y-%m-%d-%H:%M)'
+    let time = '$(date +%Y-%m-%d-%H:%M:%S)';
+    // get Android version
+    let version = getAndroidVersion(deviceId).version.trim();
 
-    GLib.spawn_async(null, ["bash", "-c", "adb -s "+ deviceId +" shell screencap -p | sed 's/\r$//' > ~/Desktop/screen"+ time +".png"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    // reference: http://www.stkent.com/2016/08/28/capturing-Nougat-screenshots-using-adb-shell.html
+    // if Nougat (7) use new direct method
+    if (version >= 7) {
+        GLib.spawn_async(null, ["bash", "-c", "adb -s " + deviceId + " shell screencap -p > ~/Desktop/screen" + time + ".png"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    } else {
+        // if lower than Nougat use old method
+        GLib.spawn_async(null, ["bash", "-c", "adb -s " + deviceId + " shell screencap -p | sed 's/\r$//' > ~/Desktop/screen" + time + ".png"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+        // in case the image is corrupted comment the line above and uncomment line under
+        //GLib.spawn_async(null, ["bash", "-c", "adb -s "+ deviceId +" shell screencap -p | perl -pe 's/\x0D\x0A/\x0A/g' > ~/Desktop/screen"+ time +".png"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    }
+
 }
 
 function recordScreen(deviceId) {
-    let time = '$(date +%Y-%m-%d-%H:%M)'
-    GLib.spawn_async(null, ["bash", "-c", "adb -s "+ deviceId +" shell screenrecord /sdcard/screenrecord.mp4"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let time = '$(date +%Y-%m-%d-%H:%M:%S)';
+    GLib.spawn_async(null, ["bash", "-c", "adb -s " + deviceId + " shell screenrecord /sdcard/screenrecord.mp4"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 
 }
 
-function stopScreenRecording(deviceId, pid) {
-    let time = '$(date +%Y-%m-%d-%H:%M)'
+function stopScreenRecording(deviceId) {
+    let time = '$(date +%Y-%m-%d-%H:%M:%S)';
+    // get PID of the screenrecord process
+    let pid = getScreenrecordPid(deviceId).pid.trim();
 
-    GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId +" shell pkill -INT screenrecord"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
-    GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId +" pull /sdcard/screenrecord.mp4 ~/Desktop/record"+ time +".mp4"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
-
+    GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " shell kill -SIGINT " + pid], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    //GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId +" pull /sdcard/screenrecord.mp4 ~/Desktop/screenrecord-"+ time +".mp4"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    // kill screencrecord causes unexpected end of the video. Sleep 1 gives us 1 s to finish the screenrecord process. Increase if video still corrputed
+    GLib.spawn_sync(null, ["bash", "-c", "sleep 1; adb -s " + deviceId + " pull /sdcard/screenrecord.mp4 ~/Desktop/screenrecord-" + time + ".mp4"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 }
 
 function establishTCPConnection(deviceId) {
 
     let deviceIp = getDeviceIp(deviceId);
 
-    GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId + " tcpip 5555"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
-    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId + " connect " + deviceIp+":5555"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " tcpip 5555"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " connect " + deviceIp + ":5555"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 
     return out.toString().trim();
 
@@ -94,12 +139,12 @@ function useUsb() {
 }
 
 function captureBugReport(deviceId) {
-    let time = '$(date +%Y-%m-%d-%H:%M)'
-    let [res, out, error] = GLib.spawn_async(null, ["bash", "-c", "adb -s "+ deviceId +" bugreport > ~/Desktop/bugreport"+ time +".txt"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let time = '$(date +%Y-%m-%d-%H:%M:%S)';
+    let [res, out, error] = GLib.spawn_async(null, ["bash", "-c", "adb -s " + deviceId + " bugreport > ~/Desktop/bugreport" + time + ".txt"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
 }
 
 function getDeviceIp(deviceId) {
-    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s "+ deviceId +" shell ip route | awk '{print $9}'"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
+    let [res, out, error] = GLib.spawn_sync(null, ["bash", "-c", "adb -s " + deviceId + " shell ip route | awk '{print $9}'"], null, GLib.SpawnFlags.SEARCH_PATH, null, null);
     return out.toString().trim();
 
 }

--- a/extension.js
+++ b/extension.js
@@ -70,7 +70,7 @@ const AndroidMenu = new Lang.Class({
 
         //start adb daemon if not running
         AdbHelper.startDaemon();
-        
+
     },
 
     _findDevices: function() {
@@ -96,7 +96,7 @@ const AndroidMenu = new Lang.Class({
 
         AdbHelper.takeScreenshot(device.deviceId);
         Main.notify("Screenshot saved in Desktop")
-        
+
     },
 
     _recordScreen: function(device) {
@@ -204,10 +204,10 @@ const AndroidMenu = new Lang.Class({
 
                 }
 
-                
+
             }
 
-            
+
         },
 
         _addErrorItem: function(error) {
@@ -240,7 +240,7 @@ let _indicator;
 
 function enable() {
     _indicator = new AndroidMenu;
-    
+
     Main.panel.addToStatusArea('android-menu', _indicator);
 
 }


### PR DESCRIPTION
## Changes
- Android 7.x - native screencap
- Android <7 - old trimming method with sed (optional alternative perl method)
- changed timestamp to show also seconds
- screenrecord is now killed more securelly and before copying file to computer there's a little timeout (`sleep 1`) so the kill process can end safely